### PR TITLE
Update tourist.js to fix '..' being prepended to all tour tips.

### DIFF
--- a/tourist.js
+++ b/tourist.js
@@ -619,7 +619,7 @@
 
     QTip.prototype.QTIP_DEFAULTS = {
       content: {
-        text: '..'
+        text: ''
       },
       show: {
         ready: false,


### PR DESCRIPTION
For some reason, when using QTip, Tourist is appending my own content text for each tour-step to this default. So all tooltips had '..' before my own content. Not sure why this default is being used, so let's remove it?
